### PR TITLE
Removed duplication of timers. Regenerated tree, Minor editorial comment

### DIFF
--- a/Yang/Tree/isis-tree.txt
+++ b/Yang/Tree/isis-tree.txt
@@ -3,11 +3,6 @@ module: ietf-l3-isis-topology
   augment /nw:networks/nw:network/nw:network-types:
     +--rw isis-topology!
   augment /nw:networks/nw:network/nw:node/l3t:l3-node-attributes:
-    +--rw isis-timer-attributes
-    |  +--rw lsp-mtu?        uint16
-    |  +--rw lsp-lifetime?   uint16
-    |  +--rw lsp-refresh?    rt-types:timer-value-seconds16 {lsp-refresh}?
-    |  +--rw poi-tlv?        boolean {poi-tlv}?
     +--rw isis-node-attributes
        +--rw system-id?              ietf-isis:system-id
        +--rw level?                  ietf-isis:level
@@ -23,3 +18,4 @@ module: ietf-l3-isis-topology
        +--rw interface-type?   ietf-isis:interface-type
        +--rw level?            ietf-isis:level
        +--rw is-passive?       boolean
+

--- a/Yang/ietf-l3-isis-topology.yang
+++ b/Yang/ietf-l3-isis-topology.yang
@@ -80,7 +80,7 @@ module ietf-l3-isis-topology {
   }
 
   grouping isis-link-attributes {
-     description "Identifies the IS-IS link attributes.";
+     description "Defines the IS-IS link attributes.";
      container isis-link-attributes {
       description
         "Main Container to identify the ISIS Link Attributes";
@@ -101,12 +101,7 @@ module ietf-l3-isis-topology {
   }
 
   grouping isis-node-attributes {
-    description "isis node scope attributes";
-    container isis-timer-attributes {
-      description
-        "Contains node timer attributes";
-      uses ietf-isis:lsp-parameters;
-    }
+    description "IS-IS node scope attributes";
     container isis-node-attributes {
         description
           "Main Container to identify the ISIS Node Attributes";
@@ -190,7 +185,7 @@ grouping isis-termination-point-attributes {
         isis topology";
     }
     description
-      "isis node-level attributes ";
+      "Augments L3 topology node attributes for IS-IS";
     uses isis-node-attributes;
   }
 
@@ -201,7 +196,7 @@ grouping isis-termination-point-attributes {
         IS-IS topology";
     }
     description
-      "Augments topology link configuration";
+      "Augments L3 topology link attributes for IS-IS";
     uses isis-link-attributes;
   }
 
@@ -215,7 +210,7 @@ grouping isis-termination-point-attributes {
         IS-IS topology";
     }
     description
-      "Augments topology termination point configuration";
+      "Augments L3 topology termination point attributes for IS-IS";
     uses isis-termination-point-attributes;
   }
 }

--- a/draft-ogondio-opsawg-isis-topology.md
+++ b/draft-ogondio-opsawg-isis-topology.md
@@ -48,7 +48,7 @@ contributor:
 
 --- abstract
 
-This document defines a YANG data model for representing an abstracted view of a network topology that contains Intermediate System to Intermediate System (IS-IS). This document augments the 'ietf-network' data model by adding IS-IS concepts and explains how the data model can be used to represent the IS-IS topology.
+This document defines a YANG data model for representing an abstracted view of a network topology that contains Intermediate System to Intermediate System (IS-IS). This document augments the 'ietf-network' and 'ietf-network-topology' data models by adding IS-IS concepts and explains how the data model can be used to represent the IS-IS topology.
 
 The YANG data model defined in this document conforms to the Network Management Datastore Architecture (NMDA).
 


### PR DESCRIPTION
I removed the dupliction of timers. I think duplication happened as a result of merge few months ago. If you also need mtu and tlv we can keep use from ietf-isis. My recollection is that we said we need only lsp-timeline and lsp-refresh, but if we need them just replace lsp-lifetime and lsp-refresh in node attributes with 'uses ietf-isis:lsp-parameters'

Regenerated tree

One minor editorial comment